### PR TITLE
Make render return explicit empty string to avoid TypeError during jekyll build

### DIFF
--- a/lib/octopress-comment-tag.rb
+++ b/lib/octopress-comment-tag.rb
@@ -5,7 +5,7 @@ module Octopress
   module Tags
     module Comment
       class Tag < Liquid::Tag
-        def render(context); end
+        def render(context) ''; end
       end
     end
   end

--- a/lib/octopress-comment-tag.rb
+++ b/lib/octopress-comment-tag.rb
@@ -1,7 +1,17 @@
 require "octopress-comment-tag/version"
 require "jekyll"
 
-Liquid::Template.register_tag('_', Liquid::Tag)
+module Octopress
+  module Tags
+    module Comment
+      class Tag < Liquid::Tag
+        def render(context); end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('_', Octopress::Tags::Comment::Tag)
 
 if defined? Octopress::Docs
   Octopress::Docs.add({


### PR DESCRIPTION
comment-tag at commit 6ff0cf1 produces a TypeError during jekyll build (Jekyll 4.3.1, Liquid 5.4.0, Ruby 3.1.0):

```
[snip]
Liquid Exception: no implicit conversion of nil into String in foobar.html
                    ------------------------------------------------
      Jekyll 4.3.1   Please append `--trace` to the `build` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
/usr/share/rubygems-integration/all/gems/liquid-5.4.0/lib/liquid/tag.rb:51:in `render_to_output_buffer': no implicit conversion of nil into String (TypeError)
[snip]
```

which goes away by defining the render method to explicitly return an empty String. Haven't used jekyll in a while, so unable to say when and why this regression occured. Just for reference here the source for the (abstract) Liquid::Tag returned by commit 6ff0cf1 :
https://github.com/harttle/liquidjs/blob/master/src/template/tag.ts

Possibly the proposed patch is not optimal, maybe the revert of 6ff0cf1 can be avoided with more ruby knowledge than mine.
